### PR TITLE
Wildcard Aレコードでfrontend側に転送する仕組みが完成

### DIFF
--- a/infra/envs/dev/google_certificate_manager_certificate_map.tf
+++ b/infra/envs/dev/google_certificate_manager_certificate_map.tf
@@ -1,0 +1,20 @@
+resource "google_certificate_manager_certificate_map" "frontend" {
+  name        = "i-a-shion-p"
+  description = "certificate map for i-a-shion-p"
+  labels = {
+    "terraform" : true,
+    "acc-test" : true,
+  }
+}
+
+resource "google_certificate_manager_certificate_map_entry" "i_a_shion_p" {
+  name        = "cert-map-entry"
+  description = "My acceptance test certificate map entry"
+  map         = google_certificate_manager_certificate_map.frontend.name
+  labels = {
+    "terraform" : true,
+    "acc-test" : true,
+  }
+  certificates = [google_certificate_manager_certificate.wildcard_i_a_shion_pro.id]
+  matcher      = "PRIMARY"
+}

--- a/infra/envs/dev/google_compute_address.tf
+++ b/infra/envs/dev/google_compute_address.tf
@@ -1,0 +1,3 @@
+data "google_compute_global_address" "ip_frontend" {
+  name = "ip-static-frontend"
+}

--- a/infra/envs/dev/google_compute_global_forwarding_rule.tf
+++ b/infra/envs/dev/google_compute_global_forwarding_rule.tf
@@ -1,0 +1,15 @@
+resource "google_compute_global_forwarding_rule" "lb_frontend" {
+  description           = null
+  ip_address            = data.google_compute_global_address.ip_frontend.id
+  ip_protocol           = "TCP"
+  labels                = {}
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  name                  = "lb-frontend-forwarding-rule"
+  network               = null
+  no_automate_dns_zone  = null
+  port_range            = "443-443"
+  project               = google_project.itadakimasu.project_id
+  source_ip_ranges      = []
+  subnetwork            = null
+  target                = "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/targetHttpsProxies/lb-frontend-target-proxy"
+}

--- a/infra/envs/dev/google_compute_target_https_proxy.tf
+++ b/infra/envs/dev/google_compute_target_https_proxy.tf
@@ -1,14 +1,17 @@
 resource "google_compute_target_https_proxy" "lb_frontend_target_proxy" {
-  certificate_map                  = null
-  description                      = null
-  http_keep_alive_timeout_sec      = 0
-  name                             = "lb-frontend-target-proxy"
-  project                          = google_project.itadakimasu.project_id
-  proxy_bind                       = false
-  quic_override                    = "NONE"
-  server_tls_policy                = null
-  ssl_certificates                 = ["https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/i-a-shion-pro", "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/store-i-a-shion-pro"]
-  ssl_policy                       = null
-  tls_early_data                   = "DISABLED"
-  url_map                          = "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/urlMaps/lb-frontend"
+  description                 = null
+  http_keep_alive_timeout_sec = 0
+  name                        = "lb-frontend-target-proxy"
+  project                     = google_project.itadakimasu.project_id
+  proxy_bind                  = false
+  quic_override               = "NONE"
+  server_tls_policy           = null
+  certificate_map             = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.frontend.id}"
+  ssl_certificates = [
+    "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/i-a-shion-pro",
+    "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/store-i-a-shion-pro"
+  ]
+  ssl_policy     = null
+  tls_early_data = "DISABLED"
+  url_map        = "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/urlMaps/lb-frontend"
 }

--- a/infra/envs/dev/google_compute_target_https_proxy.tf
+++ b/infra/envs/dev/google_compute_target_https_proxy.tf
@@ -1,0 +1,14 @@
+resource "google_compute_target_https_proxy" "lb_frontend_target_proxy" {
+  certificate_map                  = null
+  description                      = null
+  http_keep_alive_timeout_sec      = 0
+  name                             = "lb-frontend-target-proxy"
+  project                          = google_project.itadakimasu.project_id
+  proxy_bind                       = false
+  quic_override                    = "NONE"
+  server_tls_policy                = null
+  ssl_certificates                 = ["https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/i-a-shion-pro", "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/sslCertificates/store-i-a-shion-pro"]
+  ssl_policy                       = null
+  tls_early_data                   = "DISABLED"
+  url_map                          = "https://www.googleapis.com/compute/v1/projects/itadakimasu-engulid/global/urlMaps/lb-frontend"
+}

--- a/infra/envs/dev/google_dns.tf
+++ b/infra/envs/dev/google_dns.tf
@@ -16,20 +16,6 @@ resource "google_dns_record_set" "soa" {
   type         = "SOA"
 }
 
-resource "google_dns_record_set" "wildcard_cname_2_store" {
-  managed_zone = google_dns_managed_zone.default.name
-  name         = "*.i.a.shion.pro."
-  project      = google_project.itadakimasu.project_id
-  ttl          = 3600
-  type         = "CNAME"
-  routing_policy {
-    wrr {
-      rrdatas = ["store.i.a.shion.pro."]
-      weight  = 1000
-    }
-  }
-}
-
 resource "google_dns_managed_zone" "default" {
   description   = null
   dns_name      = "i.a.shion.pro."

--- a/infra/envs/dev/google_dns.tf
+++ b/infra/envs/dev/google_dns.tf
@@ -34,9 +34,9 @@ resource "google_dns_managed_zone" "default" {
   }
 }
 
-resource "google_dns_record_set" "store_cname" {
+resource "google_dns_record_set" "wildcard_i_a_shion_pro" {
   managed_zone = google_dns_managed_zone.default.name
-  name         = "store.i.a.shion.pro."
+  name         = "*.i.a.shion.pro."
   project      = google_project.itadakimasu.project_id
   rrdatas      = [data.google_compute_global_address.ip_frontend.address]
   ttl          = 18000

--- a/infra/envs/dev/google_dns.tf
+++ b/infra/envs/dev/google_dns.tf
@@ -2,9 +2,14 @@ resource "google_dns_record_set" "ns" {
   managed_zone = google_dns_managed_zone.default.name
   name         = "i.a.shion.pro."
   project      = google_project.itadakimasu.project_id
-  rrdatas      = ["ns-cloud-a1.googledomains.com.", "ns-cloud-a2.googledomains.com.", "ns-cloud-a3.googledomains.com.", "ns-cloud-a4.googledomains.com."]
-  ttl          = 21600
-  type         = "NS"
+  rrdatas = [
+    "ns-cloud-a1.googledomains.com.",
+    "ns-cloud-a2.googledomains.com.",
+    "ns-cloud-a3.googledomains.com.",
+    "ns-cloud-a4.googledomains.com."
+  ]
+  ttl  = 21600
+  type = "NS"
 }
 
 resource "google_dns_record_set" "soa" {
@@ -33,16 +38,16 @@ resource "google_dns_record_set" "store_cname" {
   managed_zone = google_dns_managed_zone.default.name
   name         = "store.i.a.shion.pro."
   project      = google_project.itadakimasu.project_id
-  rrdatas      = ["ghs.googlehosted.com."]
+  rrdatas      = [data.google_compute_global_address.ip_frontend.address]
   ttl          = 18000
-  type         = "CNAME"
+  type         = "A"
 }
 
 resource "google_dns_record_set" "acme_challenge_i_a_shion_pro" {
-    managed_zone = google_dns_managed_zone.default.name
-    name         = "_acme-challenge_kfs2xoh3ykfhojhw.i.a.shion.pro."
-    project      = google_project.itadakimasu.project_id
-    rrdatas      = ["accefa0b-f34f-4e6e-bb84-b810a1063275.9.authorize.certificatemanager.goog."]
-    ttl          = 3600
-    type         = "CNAME"
+  managed_zone = google_dns_managed_zone.default.name
+  name         = "_acme-challenge_kfs2xoh3ykfhojhw.i.a.shion.pro."
+  project      = google_project.itadakimasu.project_id
+  rrdatas      = ["accefa0b-f34f-4e6e-bb84-b810a1063275.9.authorize.certificatemanager.goog."]
+  ttl          = 3600
+  type         = "CNAME"
 }

--- a/infra/envs/dev/google_ssl_cert.tf
+++ b/infra/envs/dev/google_ssl_cert.tf
@@ -1,0 +1,13 @@
+resource "google_certificate_manager_certificate" "wildcard_i_a_shion_pro" {
+  description = null
+  labels      = {}
+  location    = "global"
+  name        = "i-a-shion-p"
+  project     = google_project.itadakimasu.project_id
+  scope       = null
+  managed {
+    dns_authorizations = ["projects/236289982072/locations/global/dnsAuthorizations/dns-authz-i-a-shion-pro"]
+    domains            = ["i.a.shion.pro", "*.i.a.shion.pro"]
+    issuance_config    = null
+  }
+}

--- a/infra/envs/dev/imports.tf
+++ b/infra/envs/dev/imports.tf
@@ -34,11 +34,6 @@ import {
 }
 
 import {
-  id = "projects/${google_project.itadakimasu.project_id}/managedZones/custom-stores/rrsets/*.i.a.shion.pro./CNAME"
-  to = google_dns_record_set.wildcard_cname_2_store
-}
-
-import {
   id = "projects/${google_project.itadakimasu.project_id}/managedZones/custom-stores/rrsets/i.a.shion.pro./NS"
   to = google_dns_record_set.ns
 }

--- a/infra/envs/dev/imports.tf
+++ b/infra/envs/dev/imports.tf
@@ -62,3 +62,13 @@ import {
   id = "projects/${google_project.itadakimasu.project_id}/regions/asia-northeast1/subnetworks/default"
   to = google_compute_subnetwork.default
 }
+
+import {
+  id = "projects/${google_project.itadakimasu.project_id}/global/forwardingRules/lb-frontend-forwarding-rule"
+  to = google_compute_global_forwarding_rule.lb_frontend
+}
+
+import {
+  id = "projects/${google_project.itadakimasu.project_id}/global/targetHttpsProxies/lb-frontend-target-proxy"
+  to = google_compute_target_https_proxy.lb_frontend_target_proxy
+}

--- a/infra/envs/dev/imports.tf
+++ b/infra/envs/dev/imports.tf
@@ -72,3 +72,8 @@ import {
   id = "projects/${google_project.itadakimasu.project_id}/global/targetHttpsProxies/lb-frontend-target-proxy"
   to = google_compute_target_https_proxy.lb_frontend_target_proxy
 }
+
+import {
+  id = "projects/${google_project.itadakimasu.project_id}/locations/global/certificates/i-a-shion-p"
+  to = google_certificate_manager_certificate.wildcard_i_a_shion_pro
+}

--- a/infra/envs/dev/imports.tf
+++ b/infra/envs/dev/imports.tf
@@ -44,8 +44,8 @@ import {
 }
 
 import {
-  id = "projects/${google_project.itadakimasu.project_id}/managedZones/custom-stores/rrsets/store.i.a.shion.pro./CNAME"
-  to = google_dns_record_set.store_cname
+  id = "projects/${google_project.itadakimasu.project_id}/managedZones/custom-stores/rrsets/*.i.a.shion.pro./A"
+  to = google_dns_record_set.wildcard_i_a_shion_pro
 }
 
 import {


### PR DESCRIPTION
- **🧱 update record for acme_challenge *.i.a.shion.pro**
- **🧱 remove CNAME for *.i.a.shion.pro**
- **🧱 data for ip_frontend**
- **🧱 import google_compute_global_forwarding_rule google_compute_target_https_proxy**
- **🧱 import google_certificate_manager_certificate wildcard_i_a_shion_pro**
- **🧱 configure certificate_map for google_compute_target_https_proxy**
- **🧱 configure wildcard a record for *.i.a.shion.pro.**
