### PR TITLE
github_shaの変更差分による影響の解消

### DIFF
--- a/infra/envs/dev/google_cloud_run_v2.tf
+++ b/infra/envs/dev/google_cloud_run_v2.tf
@@ -64,6 +64,11 @@ resource "google_cloud_run_v2_service" "frontend" {
     tag      = null
     type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
+  lifecycle {
+    ignore_changes = [
+      template[0].labels["github_sha"]
+    ]
+  }
 }
 
 resource "google_cloud_run_v2_service" "backend" {
@@ -166,5 +171,10 @@ resource "google_cloud_run_v2_service" "backend" {
     revision = null
     tag      = null
     type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+  }
+  lifecycle {
+    ignore_changes = [
+      template[0].labels["github_sha"]
+    ]
   }
 }


### PR DESCRIPTION
## PRで実装される機能


## PRで修正される機能

Cloud Runの github_sha が無視されないことによる変更差分の検知が走ってしまっていた。 lifecycleブロックを導入して解消。

## レビューをお願いしたいポイント
